### PR TITLE
chore(rename): rename apex to strata

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ func BenchmarkMain(b *testing.B) {
 		Separator:    '_',
 		Registry:     registry,
 		PanicOnError: true,
-	}).WithPrefix("apex", "example").WithLabels("role")
+	}).WithPrefix("strata", "example").WithLabels("role")
 
 	for i := 0; i < 1000000; i++ {
 		metrics.CounterInc("foo", "example")

--- a/buckets.go
+++ b/buckets.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/counter.go
+++ b/counter.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/counter_test.go
+++ b/counter_test.go
@@ -23,7 +23,7 @@ func TestCounterWithLabels(t *testing.T) {
 	labels := map[string]string{
 		"label": "one",
 	}
-	
+
 	reg := prometheus.NewPedanticRegistry()
 	vec, err := NewCounterVec(reg, "test_total", "label")
 	assert.NoError(t, err)

--- a/counter_test.go
+++ b/counter_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"testing"
@@ -23,7 +23,7 @@ func TestCounterWithLabels(t *testing.T) {
 	labels := map[string]string{
 		"label": "one",
 	}
-
+	
 	reg := prometheus.NewPedanticRegistry()
 	vec, err := NewCounterVec(reg, "test_total", "label")
 	assert.NoError(t, err)

--- a/defaults.go
+++ b/defaults.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import "time"
 

--- a/errors.go
+++ b/errors.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"strings"

--- a/examples/main.go
+++ b/examples/main.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"ctx.sh/apex"
+	"ctx.sh/strata"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -37,7 +37,7 @@ func random(min int, max int) float64 {
 	return float64(min) + rand.Float64()*(float64(max-min))
 }
 
-func runOnce(m *apex.Metrics) {
+func runOnce(m *strata.Metrics) {
 	// Histogram timer
 	timer := m.HistogramTimer("latency")
 	defer timer.ObserveDuration()
@@ -90,28 +90,28 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
-	metrics := apex.New(apex.MetricsOpts{
+	metrics := strata.New(strata.MetricsOpts{
 		Logger:         logger,
 		Separator:      ':',
 		PanicOnError:   true,
 		ConstantLabels: []string{"role", "server"},
-		SummaryOpts: &apex.SummaryOpts{
+		SummaryOpts: &strata.SummaryOpts{
 			MaxAge:     10 * time.Minute,
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 			AgeBuckets: 5,
 		},
 		HistogramBuckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5},
-	}).WithPrefix("apex", "example")
+	}).WithPrefix("strata", "example")
 
 	var obs sync.WaitGroup
 	obs.Add(1)
 	go func() {
 		defer obs.Done()
 		logger.Info("starting metrics")
-		err := metrics.Start(apex.ServerOpts{
+		err := metrics.Start(strata.ServerOpts{
 			Port:                   9090,
 			TerminationGracePeriod: 10 * time.Second,
-			TLS: &apex.TLSOpts{
+			TLS: &strata.TLSOpts{
 				CertFile: *certFile,
 				KeyFile:  *keyFile,
 			},

--- a/gauge.go
+++ b/gauge.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/gauge_test.go
+++ b/gauge_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"testing"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module ctx.sh/apex
+module ctx.sh/strata
 
 go 1.19
 

--- a/handler.go
+++ b/handler.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"net/http"

--- a/helpers.go
+++ b/helpers.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"strconv"
@@ -50,7 +50,7 @@ func createPromString(name string, ctype MetricType, labels map[string]string, v
 	var builder strings.Builder
 	builder.WriteString("# HELP ")
 	builder.WriteString(name + " ")
-	builder.WriteString(" created automagically by apex\n")
+	builder.WriteString(" created automagically by strata\n")
 	builder.WriteString("# TYPE ")
 	builder.WriteString(name + " ")
 	builder.WriteString(string(ctype) + "\n")

--- a/histogram.go
+++ b/histogram.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import "github.com/prometheus/client_golang/prometheus"
 

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"testing"

--- a/logger.go
+++ b/logger.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 type Logger interface {
 	Info(msg string, keysAndValues ...any)

--- a/metrics.go
+++ b/metrics.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"fmt"
@@ -59,7 +59,7 @@ type MetricsOpts struct {
 	// PanicOnError maintains the default behavior of prometheus to panic on
 	// errors. If this value is set to false, the library attempts to recover
 	// from any panics and emits an internally managed metric
-	// apex_errors_panic_recovery to inform the operator that visibility is
+	// strata_errors_panic_recovery to inform the operator that visibility is
 	// degraded. If set to true the original behavior is maintained and all
 	// errors are treated as panics.
 	PanicOnError bool
@@ -127,18 +127,18 @@ func (m *Metrics) Stop() {
 // metric names that are added. By default metrics are created without prefixes
 // unless added in MetricOpts. For example:
 //
-//	m := apex.New(apex.MetricsOpts{})
+//	m := strata.New(strata.MetricsOpts{})
 //	// prefix: ""
-//	m.WithPrefix("apex", "example")
-//	// prefix: "apex_example"
+//	m.WithPrefix("strata", "example")
+//	// prefix: "strata_example"
 //	m.CounterInc("a_total")
-//	// metric: "apex_example_a_total"
+//	// metric: "strata_example_a_total"
 //	n := m.WithPrefix("component")
-//	// prefix: "apex_example_component"
+//	// prefix: "strata_example_component"
 //	n.CounterInc("b_total")
-//	// metric: "apex_example_component_b_total"
+//	// metric: "strata_example_component_b_total"
 //	m.CounterInc("c_total")
-//	// metric: "apex_example_c_total"
+//	// metric: "strata_example_c_total"
 func (m *Metrics) WithPrefix(prefix ...string) *Metrics {
 	p := strings.Join(prefix, string(m.separator))
 	newPrefix := prefixedName(m.prefix, p, m.separator)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"fmt"
@@ -19,17 +19,17 @@ func TestMetricsCounter(t *testing.T) {
 	m.CounterInc(name, "us-east-1")
 	vec, err := getCounter(m, prefixedName(m.prefix, name, m.separator))
 	assert.NoError(t, err)
-	CollectAndCompare(t, vec, "apex_example_test_total", "counter", labels, 1.0)
+	CollectAndCompare(t, vec, "strata_example_test_total", "counter", labels, 1.0)
 	m.CounterAdd(name, 5.0, "us-east-1")
-	CollectAndCompare(t, vec, "apex_example_test_total", "counter", labels, 6.0)
+	CollectAndCompare(t, vec, "strata_example_test_total", "counter", labels, 6.0)
 
 	m1 := m.WithPrefix("next")
 	m1.CounterInc(name)
 	vec, err = getCounter(m1, prefixedName(m1.prefix, name, m1.separator))
 	assert.NoError(t, err)
-	CollectAndCompare(t, vec, "apex_example_next_test_total", "counter", nil, 1.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_total", "counter", nil, 1.0)
 	m1.CounterAdd(name, 5.0)
-	CollectAndCompare(t, vec, "apex_example_next_test_total", "counter", nil, 6.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_total", "counter", nil, 6.0)
 }
 
 func TestMetricsGauge(t *testing.T) {
@@ -39,29 +39,29 @@ func TestMetricsGauge(t *testing.T) {
 	m.GaugeInc(name, "us-east-1")
 	vec, err := getGauge(m, prefixedName(m.prefix, name, m.separator))
 	assert.NoError(t, err)
-	CollectAndCompare(t, vec, "apex_example_test_g", "gauge", labels, 1.0)
+	CollectAndCompare(t, vec, "strata_example_test_g", "gauge", labels, 1.0)
 	m.GaugeAdd(name, 5.0, "us-east-1")
-	CollectAndCompare(t, vec, "apex_example_test_g", "gauge", labels, 6.0)
+	CollectAndCompare(t, vec, "strata_example_test_g", "gauge", labels, 6.0)
 	m.GaugeSet(name, 10.0, "us-east-1")
-	CollectAndCompare(t, vec, "apex_example_test_g", "gauge", labels, 10.0)
+	CollectAndCompare(t, vec, "strata_example_test_g", "gauge", labels, 10.0)
 	m.GaugeDec(name, "us-east-1")
-	CollectAndCompare(t, vec, "apex_example_test_g", "gauge", labels, 9.0)
+	CollectAndCompare(t, vec, "strata_example_test_g", "gauge", labels, 9.0)
 	m.GaugeSub(name, 9.0, "us-east-1")
-	CollectAndCompare(t, vec, "apex_example_test_g", "gauge", labels, 0.0)
+	CollectAndCompare(t, vec, "strata_example_test_g", "gauge", labels, 0.0)
 
 	m1 := m.WithPrefix("next")
 	m1.GaugeInc(name)
 	vec, err = getGauge(m, prefixedName(m1.prefix, name, m1.separator))
 	assert.NoError(t, err)
-	CollectAndCompare(t, vec, "apex_example_next_test_g", "gauge", nil, 1.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_g", "gauge", nil, 1.0)
 	m1.GaugeAdd(name, 5.0)
-	CollectAndCompare(t, vec, "apex_example_next_test_g", "gauge", nil, 6.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_g", "gauge", nil, 6.0)
 	m1.GaugeSet(name, 10.0)
-	CollectAndCompare(t, vec, "apex_example_next_test_g", "gauge", nil, 10.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_g", "gauge", nil, 10.0)
 	m1.GaugeDec(name)
-	CollectAndCompare(t, vec, "apex_example_next_test_g", "gauge", nil, 9.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_g", "gauge", nil, 9.0)
 	m1.GaugeSub(name, 9.0)
-	CollectAndCompare(t, vec, "apex_example_next_test_g", "gauge", nil, 0.0)
+	CollectAndCompare(t, vec, "strata_example_next_test_g", "gauge", nil, 0.0)
 }
 
 func getCounter(metrics *Metrics, n string) (MetricVec, error) {
@@ -84,7 +84,7 @@ func testMetrics() *Metrics {
 		Separator:    '_',
 		Registry:     registry,
 		PanicOnError: true,
-	}).WithPrefix("apex", "example")
+	}).WithPrefix("strata", "example")
 
 	return metrics
 }

--- a/server.go
+++ b/server.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"context"

--- a/store.go
+++ b/store.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"sync"

--- a/summary.go
+++ b/summary.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/summary_test.go
+++ b/summary_test.go
@@ -1,4 +1,4 @@
-package apex
+package strata
 
 import (
 	"testing"

--- a/timer.go
+++ b/timer.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/types.go
+++ b/types.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,23 +26,23 @@ import (
 type MetricType string
 
 const (
-	// CounterType represents an apex wrapper around the prometheus CounterVec
+	// CounterType represents an strata wrapper around the prometheus CounterVec
 	// type.
 	CounterType MetricType = "counter"
-	// GaugeType represents an apex wrapper around the prometheus GaugeVec
+	// GaugeType represents an strata wrapper around the prometheus GaugeVec
 	// type.
 	GaugeType MetricType = "gauge"
-	// SummaryType represents an apex wrapper around the prometheus SummaryVec
+	// SummaryType represents an strata wrapper around the prometheus SummaryVec
 	// type.
 	SummaryType MetricType = "summary"
-	// HistogramType represents an apex wrapper around the prometheus HistogramVec
+	// HistogramType represents an strata wrapper around the prometheus HistogramVec
 	// type.
 	HistogramType MetricType = "histogram"
 	// Defines the metrics help string.  This is currently not settable.
-	DefaultHelpString string = "created automagically by apex"
+	DefaultHelpString string = "created automagically by strata"
 )
 
-// MetricVec defines the interface for apex metrics collector wrappers.
+// MetricVec defines the interface for strata metrics collector wrappers.
 type MetricVec interface {
 	Name() string
 	Type() MetricType

--- a/util.go
+++ b/util.go
@@ -17,7 +17,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package apex
+package strata
 
 import (
 	"github.com/prometheus/client_golang/prometheus"


### PR DESCRIPTION
Rename apex.  There are a few packages out in the wild that share that specific name and I don't want any future overlap especially when I start building the client in other languages.