### PR TITLE
feat(context): context functions

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,25 @@
+package strata
+
+import "context"
+
+type metricsKey struct{}
+
+// FromContext extracts and returns the Metrics from the context.  An error is
+// returned if the context does not contain Metrics or the context is nil.
+func FromContext(ctx context.Context, prefix ...string) (*Metrics, error) {
+	if ctx != nil {
+		if metrics, ok := ctx.Value(metricsKey{}).(*Metrics); ok {
+			return metrics, nil
+		}
+
+		return nil, ErrNoMetrics
+	}
+
+	return nil, ErrNilContext
+}
+
+// IntoContext returns a new context derived from the provided context which
+// carries the provided Metrics.
+func IntoContext(ctx context.Context, metrics *Metrics) context.Context {
+	return context.WithValue(ctx, metricsKey{}, metrics)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,16 @@
+package strata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext(t *testing.T) {
+	m := New(MetricsOpts{})
+	ctx := IntoContext(context.Background(), m)
+	m2, err := FromContext(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, m, m2)
+}

--- a/errors.go
+++ b/errors.go
@@ -25,22 +25,27 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-type ApexError string
+type StrataError string
 
 const (
 	// ErrInvalidMetricName is returned when a metric name contains other
 	// characters other than [a-zA-Z_-].
-	ErrInvalidMetricName = ApexError("Invalid metric name")
+	ErrInvalidMetricName = StrataError("Invalid metric name")
 	// ErrRegistrationFailed is returned if prometheus is unable to register
 	// the collector.
-	ErrRegistrationFailed = ApexError("Unable to register collector")
+	ErrRegistrationFailed = StrataError("Unable to register collector")
 	// ErrAlreadyRegistered is returned if prometheus has already registered
 	// a collector.
-	ErrAlreadyRegistered = ApexError("metric is already registered")
+	ErrAlreadyRegistered = StrataError("metric is already registered")
+	// ErrNoMetrics is returned if the context does not contain the metrics
+	// key.
+	ErrNoMetrics = StrataError("no metrics found in context")
+	// ErrNilContext is returned if the context is nil.
+	ErrNilContext = StrataError("context is nil")
 )
 
-// Error implements the error interface for ApexError.
-func (e ApexError) Error() string {
+// Error implements the error interface for StrataError.
+func (e StrataError) Error() string {
 	return string(e)
 }
 


### PR DESCRIPTION
Provides context transport and extraction functions. This is still early and I want a chance to test it out in a couple places before it is "officially" added to the documentation.

As an aside, when working through the context components I thought that it would be useful to have an implementation that could just return a "discard" implementation of the metrics instead of returning nil.  I'm considering a refactor to pull out Metrics into an interface so I can add that Discard implementation and maybe actually extend this to handle more than just prometheus. For now, this should be fine.